### PR TITLE
Added bottom Error Panel

### DIFF
--- a/.sublimets
+++ b/.sublimets
@@ -1,0 +1,3 @@
+{
+    "root":"test/test.ts"
+}

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,7 @@
+[
+    {
+        "caption": "Typescript: Show Error Panel",
+        "command": "typescript_show_error_panel"
+    },
+
+]

--- a/Typescript.py
+++ b/Typescript.py
@@ -11,6 +11,10 @@ import json
 import re
 import sys
 
+from .errors import TypescriptErrorPanel, TypescriptWindowManager
+
+window_manager = TypescriptWindowManager()
+
 
 # --------------------------------------- CONSTANT -------------------------------------- #
 
@@ -278,7 +282,10 @@ class Tss(object):
 				a = view.text_point(start_line-1,left-1)
 				b = view.text_point(end_line-1,right-1)
 				char_regions.append( sublime.Region(a,b))
+				e['region'] = (a,b)
 				ERRORS[filename][(a,b)] = e['text']
+
+		window_manager.errors_for_view(view).add(errors)
 
 		view.add_regions('typescript-error' , char_regions , 'invalid' , ICONS_PATH)
 
@@ -547,6 +554,15 @@ def join_segments(liste,length):
 
 	return os.path.realpath(join)
 
+
+
+# ---------------------------------------- ERROR PANEL ----------------------------------------- #
+class TypescriptShowErrorPanelCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        print("Show Error Panel")
+        error_list = window_manager.errors_for_window(sublime.active_window())
+        panel = TypescriptErrorPanel()
+        panel.show_errors(error_list)
 
 
 # ---------------------------------------- PLUGIN LOADED --------------------------------------- #

--- a/TypescriptBuild.tmLanguage
+++ b/TypescriptBuild.tmLanguage
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>comment</key>
+    <string>TypeScript Build Output</string>
+    <key>name</key>
+    <string>TypeScript Build Output</string>
+    <key>patterns</key>
+    <array>
+<!--         <dict>
+            <key>match</key>
+            <string>((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b</string>
+            <key>name</key>
+            <string>invalid.deprecated</string>
+        </dict>
+ -->
+        <dict>
+            <key>match</key>
+            <string>^\s\S.*</string>
+            <key>name</key>
+            <string>error.flag</string>
+        </dict>        
+
+        <dict>
+            <key>match</key>
+            <string>Line \d+:</string>
+            <key>name</key>
+            <string>error.line</string>
+        </dict>                
+
+
+<!--         <dict>
+            <key>match</key>
+            <string>\[ERR\] .*+</string>
+            <key>name</key>
+            <string>error.header</string>
+        </dict>
+ -->
+
+<!--         <dict>
+            <key>match</key>
+            <string>\[!\] [0-9]+:.*</string>
+            <key>name</key>
+            <string>error.details</string>
+        </dict> 
+ -->
+        <dict>
+            <key>match</key>
+            <string>\[OK\]</string>
+            <key>name</key>
+            <string>ok</string>
+        </dict>      
+    </array>    
+    <key>scopeName</key>
+    <string>source.tsfat</string>
+</dict>
+</plist>

--- a/TypescriptBuild.tmTheme
+++ b/TypescriptBuild.tmTheme
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Typescript Build</string>
+    <key>settings</key>
+    <array>
+        <dict>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#1E1E1AF2</string>
+                <key>caret</key>
+                <string>#F8F8F0</string>
+                <key>foreground</key>
+                <string>#FFFFFF</string>
+                <key>invisibles</key>
+                <string>#8A88774D</string>
+                <key>lineHighlight</key>
+                <string>#FFFCDC08</string>
+                <key>selection</key>
+                <string>#49483E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Comment</string>
+            <key>scope</key>
+            <string>comment</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#75715E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>String</string>
+            <key>scope</key>
+            <string>string</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#E6DB741A</string>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#E6DB74</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Regexp</string>
+            <key>scope</key>
+            <string>string.regexp</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#FF8000</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Number</string>
+            <key>scope</key>
+            <string>constant.numeric</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#FF0080</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Built-in constant</string>
+            <key>scope</key>
+            <string>constant.language</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#A6E22E1A</string>
+                <key>foreground</key>
+                <string>#A6E22E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>User-defined constant</string>
+            <key>scope</key>
+            <string>constant.character, constant.other</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#A6E22E1A</string>
+                <key>foreground</key>
+                <string>#B4F83A</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Variable</string>
+            <key>scope</key>
+            <string>variable</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Keyword</string>
+            <key>scope</key>
+            <string>keyword</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#5CAAF6</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Storage</string>
+            <key>scope</key>
+            <string>storage</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#F92672</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Storage type</string>
+            <key>scope</key>
+            <string>storage.type</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#66D9EF</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Class name</string>
+            <key>scope</key>
+            <string>entity.name.class</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string>underline</string>
+                <key>foreground</key>
+                <string>#A6E22E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Function name</string>
+            <key>scope</key>
+            <string>entity.name.function</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#00FF80</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Function argument</string>
+            <key>scope</key>
+            <string>variable.parameter</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#FADC3F</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Tag name</string>
+            <key>scope</key>
+            <string>entity.name.tag</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#66CCFF</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Tag attribute</string>
+            <key>scope</key>
+            <string>entity.other.attribute-name</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#A6E22E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Library function</string>
+            <key>scope</key>
+            <string>support.function</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#66D9EF</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Library constant</string>
+            <key>scope</key>
+            <string>support.constant</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#66D9EF</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Library class/type</string>
+            <key>scope</key>
+            <string>support.type, support.class</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#66D9EF</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Library variable</string>
+            <key>scope</key>
+            <string>support.other.variable</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Local variable</string>
+            <key>scope</key>
+            <string>variable.other</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#B3B3B3</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Invalid</string>
+            <key>scope</key>
+            <string>invalid</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#FF0080</string>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#F8F8F0</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Invalid deprecated</string>
+            <key>scope</key>
+            <string>invalid.deprecated</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#AE81FF</string>
+                <key>foreground</key>
+                <string>#F8F8F0</string>
+            </dict>
+        </dict>
+
+
+
+        <dict>
+            <key>name</key>
+            <string>Error Header</string>
+            <key>scope</key>
+            <string>error.header</string>
+            <key>settings</key>
+            <dict>
+                <!-- <key>background</key> -->
+                <!-- <string>#FF0080</string> -->
+                <key>fontStyle</key>
+                <string>bold</string>
+                <key>foreground</key>
+                <string>#F8F8F0</string>
+            </dict>
+        </dict>
+
+
+        <dict>
+            <key>name</key>
+            <string>Error Flag</string>
+            <key>scope</key>
+            <string>error.flag</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#880000</string>
+                <key>fontStyle</key>
+                <string>bold</string>
+                <key>foreground</key>
+                <string>#FFFFFF</string>
+            </dict>
+        </dict>
+
+        <dict>
+            <key>name</key>
+            <string>Error Line</string>
+            <key>scope</key>
+            <string>error.line</string>
+            <key>settings</key>
+            <dict>
+                <!-- <key>background</key> -->
+                <!-- <string>#FF0080</string> -->
+                <key>fontStyle</key>
+                <string>bold</string>
+                <key>foreground</key>
+                <string>#FF7777</string>
+            </dict>
+        </dict>
+
+
+        <dict>
+            <key>name</key>
+            <string>Error Details</string>
+            <key>scope</key>
+            <string>error.details</string>
+            <key>settings</key>
+            <dict>
+<!--                 <key>background</key>
+                <string>#AE81FF</string>
+ -->                <key>foreground</key>
+                <string>#F8F8F0</string>
+            </dict>
+        </dict>
+    </array>
+    <key>uuid</key>
+    <string>7030E08A-948F-47D2-A9C1-C3E7546845A5</string>
+</dict>
+</plist>

--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,263 @@
+from os import path
+import sublime
+import sublime_plugin
+from sublime_plugin import TextCommand, EventListener, WindowCommand
+
+# base_dir = path.dirname(path.abspath(__file__))
+# icons_dir = path.join('..', path.basename(base_dir), 'icons')
+# illegal_icon = path.join(icons_dir, 'simple-illegal')
+# warning_icon = path.join(icons_dir, 'simple-warning')
+# draw_style = sublime.DRAW_STIPPLED_UNDERLINE | sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE
+
+# TODO: detect whether the same error has been added twice (check ranges, or use ranges as a key)
+# -- happens a lot in my project with an error in the node library
+
+# Creates an error manager and other assets unique to the window
+class TypescriptWindowManager(object):
+
+    def __init__(self):
+        self.errors = {}
+
+    # returns an initializes a project given a certain view
+    def errors_for_view(self, view):
+        if not view: return None
+        return self.errors_for_window(view.window())
+
+    def errors_for_window(self, window):
+        window_id = str(window.id())
+
+        if not (window_id in self.errors):
+            self.errors[window_id] = ErrorList(window_id)
+
+        return self.errors[window_id]
+
+    def unload(self):
+        self.errors = {}
+
+
+
+# errors should be by WINDOW
+class ErrorList():
+    def __init__(self, id):
+        self.id = id
+        self.errors_by_file = {}
+
+    def add(self, errors):
+
+        # for each file, set them to nil
+        errors_by_file = {}
+        for e in errors:
+            file = e['file']
+            print(" - ", file, e['text'])
+            if not (file in errors_by_file):
+                errors_by_file[file] = []
+
+            errors_by_file[file].append(e)
+
+        # for file in errors_by_file:
+        self.errors_by_file = errors_by_file
+
+    def by_file(self, file):
+        return self.errors_by_file[file]
+
+    def files(self):
+        return self.errors_by_file.keys()
+
+class TypescriptErrorPanel():
+
+    # def __init__(self):
+    #     # self.output
+    #     print("HI")
+
+    def output_create(self):
+        self.output = sublime.active_window().create_output_panel('typescript_errors')
+        self.output.set_syntax_file("Packages/T3S/TypescriptBuild.tmLanguage")
+        self.output.settings().set("color_scheme", "Packages/T3S/TypescriptBuild.tmTheme")
+
+    def output_open(self):
+        sublime.active_window().run_command("show_panel", {"panel": "output.typescript_errors"})
+
+
+    def output_close(self):
+        sublime.active_window().run_command("hide_panel", {"panel": "output.typescript_errors"})
+
+
+    def output_append(self, characters):
+        self.output.run_command('append', {'characters': characters})
+
+    def show_errors(self, error_list):
+        print("SHOW ERRORS2", len(error_list.errors_by_file))
+        self.output_create()
+        self.output.set_read_only(False)
+
+        regions = []
+        for file in error_list.files():
+            errors = error_list.by_file(file)
+            print("file", file, len(errors))
+            if not errors:
+                continue
+
+            self.output_append('{0}\n'.format(file.replace(active_window_root_folder(), "").replace("/","",1)))
+
+            for error in errors:
+                region_text = 'Line {0}:'.format(error['start']['line'] + 1)
+                region_start = self.output.size() + 2
+                regions.append(sublime.Region(region_start, region_start + len(region_text)))
+                self.output_append('  {0} {1}\n'.format(region_text, error['text']))
+
+            self.output_append('\n')
+
+        self.output.add_regions('typescript-illegal', regions, 'error.line', '', sublime.DRAW_NO_FILL)
+        self.output.set_read_only(True)
+        self.output_open()
+
+
+def active_window_root_folder():
+    open_folders = sublime.active_window().folders()
+    if (len(open_folders) > 0):
+        return open_folders[0]
+    else:
+        return ""
+
+class SubtypeErrorsListener(sublime_plugin.EventListener):
+
+    def on_selection_modified_async(self, view):
+        if view.settings().get('syntax').lower().endswith('typescriptbuild.tmlanguage'):
+            error_regions = []
+            error_regions.extend(view.get_regions('typescript-illegal'))
+            error_regions.extend(view.get_regions('typescript-warning'))
+
+            sel_point = view.sel()[0].a
+            paths = view.substr(sublime.Region(0, view.size())).split('\n')
+            print("PATHS", paths)
+
+            last_file = None
+            for x in range(len(paths)):
+                if paths[x].startswith('  '):
+                    paths[x] = last_file
+                else:
+                    last_file = paths[x]
+
+            for region in error_regions:
+                if region.contains(sel_point):
+                    row = view.rowcol(sel_point)[0]
+                    line = view.substr(region)[5:]
+                    
+                    abspath = path.join(active_window_root_folder(), paths[row])
+                    print("GOGOG2O?", abspath, line)
+                    pathline = '{0}:{1}'.format(abspath, line)
+                    sublime.active_window().open_file(pathline, sublime.ENCODED_POSITION)
+
+
+# class ErrorManager():
+
+#     def __init__(self, interface_manager):
+#         self.interface_manager = interface_manager
+#         self.errors_by_path = {}
+#         self.errors_by_viewid = {}
+
+
+#     def add_file(self, f):
+#         self.errors_by_path[f.path] = []
+
+
+#     def remove_file(self, f):
+#         del self.errors_by_path[f.path]
+
+
+#     def draw_errors(self, view, errors):
+#         illegals = []
+#         warnings = []
+
+#         for e in errors:
+#             if not e.get('region'):
+#                 start = view.text_point(*e['start'])
+#                 end = view.text_point(*e['end'])
+#                 e['region'] = sublime.Region(start, end)
+
+#             if e['level'] == 'illegal':
+#                 illegals.append(e['region'])
+#             else:
+#                 warnings.append(e['region'])
+
+#         view.add_regions('typescript-illegal', illegals, 'sublimelinter.outline.illegal', illegal_icon, draw_style)
+#         view.add_regions('typescript-warning', warnings, 'sublimelinter.outline.warning', warning_icon, draw_style)
+
+#         self.errors_by_viewid[view.id()] = errors
+
+
+#     def parse(self, errors, interface):
+#         all_views = []
+
+#         self.clear_interface(interface)
+
+#         errors_by_path = {}
+
+#         for e in errors:
+#             if e['file'] not in errors_by_path:
+#                 errors_by_path[e['file']] = []
+
+#             errors_by_path[e['file']].append(e)
+
+#         for path in errors_by_path.keys():
+#             for view in self.interface_manager.get_views(path):
+#                 self.draw_errors(view, errors_by_path[path])
+
+#         self.errors_by_path.update(errors_by_path)
+
+
+#     def clear_interface(self, interface):
+#         if self.interface_manager.get_active_paths(interface):
+#             for path in interface.files:
+#                 for view in self.interface_manager.get_views(path):
+#                     self.clear_view(view)
+
+#                 if path not in self.errors_by_path:
+#                     raise Exception('Handling errors for unkown file')
+
+#                 self.errors_by_path[path] = []
+
+#     def clear_view(self, view):
+#         view.erase_regions('typescript-illegal')
+#         view.erase_regions('typescript-warning')
+
+#         if view.id() in self.errors_by_viewid:
+#             del self.errors_by_viewid[view.id()]
+
+
+#     def get(self, view, point=None):
+#         errors = self.errors_by_viewid.get(view.id(), [])
+
+#         if point is None:
+#             return errors
+#         else:
+#             return [e for e in errors if e['region'].contains(point)]
+
+
+
+
+
+# class SubtypeErrorsListener(sublime_plugin.EventListener):
+
+#     def on_selection_modified_async(self, view):
+#         if view.settings().get('syntax').lower().endswith('typescriptbuild.tmlanguage'):
+#             error_regions = []
+#             error_regions.extend(view.get_regions('typescript-illegal'))
+#             error_regions.extend(view.get_regions('typescript-warning'))
+
+#             sel_point = view.sel()[0].a
+#             paths = view.substr(sublime.Region(0, view.size())).split('\n')
+
+#             last_file = None
+#             for x in range(len(paths)):
+#                 if paths[x].startswith('  '):
+#                     paths[x] = last_file
+#                 else:
+#                     last_file = paths[x]
+
+#             for region in error_regions:
+#                 if region.contains(sel_point):
+#                     row = view.rowcol(sel_point)[0]
+#                     line = view.substr(region)[5:]
+#                     path = '{0}:{1}'.format(paths[row], line)
+#                     sublime.active_window().open_file(path, sublime.ENCODED_POSITION)

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,11 @@
+document.addEventListener("keydown", function() {
+
+})
+
+interface User {
+    username: string;
+    password: string;
+}
+
+var bobby:User;
+bobby.username = 1;


### PR DESCRIPTION
Hi Railk!

Good work on the plugin. I've been keeping quiet for a while and it looks like the intertubes have chosen your plugin as the standard. There are a few things that I really want to improve and I'd like to spend a little time over the next month or two adding some pull requests. 

The first thing is adding an error panel at the bottom that shows all the project errors. I know the error panel you have implemented lets you jump to specific errors, but I find it very hard to read. It is also impossible to keep working while you leave the panel open. 

I haven't changed any of the default functionality yet. The only way to access this is through the command interface: "Tools -> Command Palette -> Typescript: Show Error Panel"

Next steps: 
- If open, it would update automatically whenever errors changed. 
- I think it would be best to replace yours with this, including the key command
- have an option to display this panel automatically on save
