### PR TITLE
OSX and UTF-8 fixes

### DIFF
--- a/lib/Utils.py
+++ b/lib/Utils.py
@@ -6,6 +6,7 @@ import subprocess
 import os
 import re
 import json
+import codecs
 
 
 # PACKAGE PATH
@@ -108,11 +109,14 @@ def thread_safe(fn,args=None):
 def get_data(file,decode=False):
 	if os.path.isfile(file): 
 		try: 
-			f = open(file,'r').read()
+			f = codecs.open(file,'r', 'utf-8').read()
 			if decode: return json.loads(f)
 			else: return f
 		except IOError: 
 			pass
+		except Exception as e:
+			print("get_data error:", file, decode, e)
+			raise
 
 	return None
 

--- a/lib/system/Settings.py
+++ b/lib/system/Settings.py
@@ -44,14 +44,13 @@ class Settings(object):
 		project_settings = view.settings().get('typescript')
 		current_folder = os.path.dirname(view.file_name())
 		top_folder =  self.get_top_folder(current_folder)
-		top_folder_segments = top_folder.split(os.sep)
 		has_project_settings = project_settings != None and hasattr(project_settings, 'get')
 
 		# DO WE HAVE ROOT FILES DEFINED INSIDE THE PROJECT FILE
 		if has_project_settings:
 			roots = project_settings.get('roots')
 			for root in roots:
-				root_path = os.sep.join(top_folder_segments[:len(top_folder_segments)-1]+root.replace('\\','/').split('/'))
+				root_path = os.path.join(top_folder, root)
 				root_top_folder = self.get_top_folder(os.path.dirname(root_path))
 				if current_folder.lower().startswith(root_top_folder.lower()):
 					if root_path not in self.projects_type: 


### PR DESCRIPTION
Splitting the file path into segments was failing on posix systems because the path starts with a "/", which meant that `len(top_folder_segments)-1` lost the last folder segment. I switched to os.path.join() instead since it seems to do what you intended more simply. 

I changed the `get_data` function in Utils to read files in `utf-8` because it was failing on one of mine. 

Do these changes still work for you on windows?

Also note: when I put a `print()` in `get_data` it was reading the file I had open dozens of times. Is that expected?
