### PR TITLE
Fix clash with Vintageous.

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,7 +3,7 @@
 		"command": "typescript_complete",
 		"args": {"characters": "."},
 		"keys": ["."],
-		"context": [ {"key": "T3S"} ]
+		"context": [ {"key": "T3S", "key": "vi_must_change_mode"}, {"key": "vi_is_buffer"} ]
 	},
 	{
 		"command": "typescript_complete",


### PR DESCRIPTION
If you're using T3S and Vintageous at the same time, the "." key that Vintageous uses to repeat the last command won't work - it'll just insert a dot. The change I proposed here just ensures you're in insert mode before you do anything, but it won't work if you're not even using Vintageous. I don't know how to check for that, so it'd be great if you could suggest something.

OR.

I think that the real problem and a real fix could come from this code in Typescript.py, where you force an insert of the ".":

```
class TypescriptComplete(sublime_plugin.TextCommand):
    def run(self, edit, characters):
            for region in self.view.sel():
                    self.view.insert(edit, region.end(), characters)
```

But I don't understand why you have to force an insert of the ".". Is there some way avoid doing this? It'll inevitably clash with any other plugin that wants to use the "." in some special way.
