### PR TITLE
Better syntax definition

### DIFF
--- a/Typescript.JSON-tmLanguage
+++ b/Typescript.JSON-tmLanguage
@@ -246,7 +246,7 @@
       ]
     },
     "meta-class-member-attribute": {
-      "begin": "\\b([a-zA-Z_$][\\w$]*)\\s*(?=(=|:))",
+      "begin": "\\b([a-zA-Z_$][\\w$]*)\\s*(\\?\\s*)?(?=(=|:))",
       "end": "(;)",
       "beginCaptures": {
         "1": { "name": "meta.toc-list.class.member.ts" }

--- a/Typescript.tmLanguage
+++ b/Typescript.tmLanguage
@@ -379,7 +379,7 @@
 		<key>meta-class-member-attribute</key>
 		<dict>
 			<key>begin</key>
-			<string>\b([a-zA-Z_$][\w$]*)\s*(?=(=|:))</string>
+			<string>\b([a-zA-Z_$][\w$]*)\s*(\?\s*)?(?=(=|:))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Hi, You are using same old syntax definition file like other sublime typescript plugins.
Problem is this syntax definition doesn't correctly handle class methods so they won't appear in goto symbol table. Argument types in functions are also messed up.

This will fix those issues.
I have originally created my own plugin here [SublimeTS](https://github.com/dorny/SublimeTS).
Since there are already two other used TS plugins - [sublime-better-typescript](https://github.com/lavrton/sublime-better-typescript) and yours, i have decided to rather merge my work with them.

sublime-better-typescript have already accepted pull request.
