### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ You can circle through the function variables (if there's some) like with the sn
 You can click on highlighted part to see the error description in the status bar
 
 ##### Error Panel:
-You have the possibility to open an <code>error panel</code> that will list all the errors accross all your project file with the command <code>ctrl+shift+e</code>
+You have the possibility to open an <code>error panel</code> that will list all the errors across all your project file with the command <code>ctrl+shift+e</code>
 You can then click on each row, it'll open or focus the already open file concerned by the error.
 
 ##### Reloading the project:


### PR DESCRIPTION
@Railk, I've corrected a typographical error in the documentation of the [T3S](https://github.com/Railk/T3S) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
